### PR TITLE
Fix file names in world_objects.py

### DIFF
--- a/cooking_zoo/cooking_world/world_objects.py
+++ b/cooking_zoo/cooking_world/world_objects.py
@@ -89,7 +89,7 @@ class Counter(StaticObject, ContentObject):
         return 3
 
     def file_name(self) -> str:
-        return "counter"
+        return "Counter"
 
     def icons(self) -> List[str]:
         return []
@@ -423,7 +423,7 @@ class Plate(DynamicObject, ContentObject):
         return 3
 
     def file_name(self) -> str:
-        return "Plate"
+        return "plate"
 
     def icons(self) -> List[str]:
         return []


### PR DESCRIPTION
Update the file names for `counter` and `plate` objects to match the actual file name capitalization.